### PR TITLE
Don't swallow OSErrors during compile

### DIFF
--- a/runac/__init__.py
+++ b/runac/__init__.py
@@ -73,6 +73,8 @@ def compile(ir, outfn):
 	except OSError as e:
 		if e.errno == 2:
 			print 'error: clang not found'
+		else:
+			raise
 	except subprocess.CalledProcessError:
 		pass
 	finally:


### PR DESCRIPTION
I saw this while poking around. Looks like the only tests are runa code/output pairs, so no test changes.
